### PR TITLE
fix: 메인 페이지에서 플랫폼 선택 시 파티가 없을 때 플랫폼 정보 나오지 않는 것 수정

### DIFF
--- a/src/views/PlatformListView.vue
+++ b/src/views/PlatformListView.vue
@@ -224,6 +224,9 @@ const loadInitialData = async () => {
       platformName.value = firstParty.platformName
       platformPrice.value = firstParty.platformPrice
     } else {
+      const null_response = await axios.get(`http://localhost:8080/post/platform/${platformId}/`)
+      platformName.value = null_response.data.platformName
+      platformPrice.value = null_response.data.platformPrice
       hasMore.value = false
     }
   } catch (error) {


### PR DESCRIPTION
#16 
1. 메인 페이지에서 플랫폼 선택 시 파티가 없을 때 플랫폼 정보 나오지 않는 것 수정